### PR TITLE
[Compat] Add MegaMan Battle Network Operate Star Force (NDS)

### DIFF
--- a/NDSCompat.json
+++ b/NDSCompat.json
@@ -1,6 +1,7 @@
 {
   "compatibility": [
     {
+      "rendersize": null,
       "game_name": "101-in-1 Explosive Megamix",
       "game_region": "EUR",
       "base_name": "Mario Kart DS",
@@ -9,6 +10,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "4 Game Fun Pack - Clue/Mouse Trap/Perfection/Aggravation",
       "game_region": "USA",
       "base_name": "The Legend of Zelda: Spirit Tracks",
@@ -17,6 +19,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "7th Dragon",
       "game_region": "JPN",
       "base_name": "New Super Mario Bros.",
@@ -25,6 +28,7 @@
       "notes": "Will also work with the translation patch from https://www.romhacking.net/translations/2176/"
     },
     {
+      "rendersize": null,
       "game_name": "9 Hours, 9 Persons, 9 Doors",
       "game_region": "USA",
       "base_name": "Yoshi Touch &amp; Go / New Super Mario Bros.",
@@ -33,6 +37,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "A Witch's Tale",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -41,6 +46,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Advance Wars: Days of Ruin",
       "game_region": "USA",
       "base_name": "Advance Wars: Days of Ruin",
@@ -49,6 +55,7 @@
       "notes": "Major graphical glitches and slowdown on maps."
     },
     {
+      "rendersize": null,
       "game_name": "Alex Rider: Stormbreaker",
       "game_region": "EUR",
       "base_name": "Picross 3D",
@@ -57,6 +64,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Anno 1701",
       "game_region": "USA",
       "base_name": "Picross 3D",
@@ -65,14 +73,7 @@
       "notes": "Textures of Trees and Buildings don't load and stay black."
     },
     {
-      "game_name": "Another Super Mario 3D",
-      "game_region": "USA",
-      "base_name": "Super Mario 64 DS US",
-      "base_region": "USA",
-      "status": 0,
-      "notes": "Hard crashes Wii U"
-    },
-    {
+      "rendersize": null,
       "game_name": "Another Super Mario 3D",
       "game_region": "EUR",
       "base_name": "New Super Mario Bros",
@@ -81,6 +82,7 @@
       "notes": "Just a Black Screen"
     },
     {
+      "rendersize": null,
       "game_name": "Another Super Mario 3D",
       "game_region": "EUR",
       "base_name": "Zelda Spirt Tracks",
@@ -89,6 +91,7 @@
       "notes": "Just a Black Screen"
     },
     {
+      "rendersize": null,
       "game_name": "Another Super Mario 3D",
       "game_region": "EUR",
       "base_name": "Super Mario 64 DS",
@@ -97,6 +100,16 @@
       "notes": "Just a Black Screen"
     },
     {
+      "rendersize": null,
+      "game_name": "Another Super Mario 3D",
+      "game_region": "USA",
+      "base_name": "Super Mario 64 DS US",
+      "base_region": "USA",
+      "status": 0,
+      "notes": "Hard crashes Wii U"
+    },
+    {
+      "rendersize": null,
       "game_name": "Apollo Justice Ace Attorney",
       "game_region": "USA",
       "base_name": "Metroid Prime Hunters",
@@ -105,6 +118,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Arkanoid DS",
       "game_region": "EUR",
       "base_name": "The Legend of Zelda: Spirit Tracks",
@@ -113,6 +127,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Asphalt Urban GT",
       "game_region": "EUR",
       "base_name": "Mario Kart DS",
@@ -121,6 +136,7 @@
       "notes": "Intro video sequence is sped up."
     },
     {
+      "rendersize": null,
       "game_name": "Assassin's Creed: Altaïrs Chronicles",
       "game_region": "USA",
       "base_name": "Picross 3D",
@@ -129,6 +145,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Atari Greatest Hits: Volume 1",
       "game_region": "USA",
       "base_name": "Kirby Mass Attack",
@@ -137,6 +154,7 @@
       "notes": "The main menu takes a couple seconds to become visible. Games only appear after pausing and resuming the game. Other than that, the games are completely playable."
     },
     {
+      "rendersize": null,
       "game_name": "ATX Quad Kings",
       "game_region": "EUR",
       "base_name": "Mario Kart DS",
@@ -145,6 +163,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Avalon Code",
       "game_region": "USA",
       "base_name": "The Legend of Zelda: Spirit Tracks",
@@ -153,6 +172,7 @@
       "notes": "Works perfectly"
     },
     {
+      "rendersize": null,
       "game_name": "Bangai-O Spirits",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -161,6 +181,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Batman: The Brave",
       "game_region": "USA",
       "base_name": "WarioWare: Touched!",
@@ -169,6 +190,7 @@
       "notes": "Bottom screen is black on the title screen. Top screen is freezes randomly for long periods of time on the tutorial level - if you can beat it blind, it fixes, but in some areas of the game it comes back but fixes when you open the pause menu."
     },
     {
+      "rendersize": null,
       "game_name": "Batman: The Brave",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -177,6 +199,7 @@
       "notes": "Bottom screen is black on the title screen. Top screen is freezes randomly for long periods of time on the tutorial level - if you can beat it blind, it fixes, but in some areas of the game it comes back but fixes when you open the pause menu."
     },
     {
+      "rendersize": null,
       "game_name": "Bella Sara",
       "game_region": "EUR",
       "base_name": "Mario Kart DS",
@@ -185,6 +208,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Big Bang Mini",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -193,6 +217,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Blood of Bahamut",
       "game_region": "JPN",
       "base_name": "New Super Mario Bros.",
@@ -201,6 +226,7 @@
       "notes": "Will also work with the translation patch from https://www.romhacking.net/translations/2560/"
     },
     {
+      "rendersize": null,
       "game_name": "Blue Dragon: Awakened Shadow",
       "game_region": "USA",
       "base_name": "The Legend of Zelda: Spirt Tracks US",
@@ -209,6 +235,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Bold: The Video Game",
       "game_region": "USA",
       "base_name": "WarioWare: Touched!",
@@ -217,6 +244,7 @@
       "notes": "Bottom screen is black on the title screen. Top screen is freezes randomly for long periods of time on the tutorial level - if you can beat it blind, it fixes, but in some areas of the game it comes back but fixes when you open the pause menu."
     },
     {
+      "rendersize": null,
       "game_name": "Bold: The Video Game",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -225,6 +253,7 @@
       "notes": "Bottom screen is black on the title screen. Top screen is freezes randomly for long periods of time on the tutorial level - if you can beat it blind, it fixes, but in some areas of the game it comes back but fixes when you open the pause menu."
     },
     {
+      "rendersize": null,
       "game_name": "Burnout Legends",
       "game_region": "USA",
       "base_name": "Picross 3D",
@@ -233,6 +262,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "C.O.P: The Recruit",
       "game_region": "EUR",
       "base_name": "Picross 3D",
@@ -241,6 +271,7 @@
       "notes": "Blackscreen after Ubisoft logo"
     },
     {
+      "rendersize": null,
       "game_name": "Call of Duty 4: Modern Warfare",
       "game_region": "EUR",
       "base_name": "Metroid Prime Hunters",
@@ -249,6 +280,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Call of Duty: Black Ops",
       "game_region": "USA",
       "base_name": "Metroid Prime Hunters",
@@ -257,6 +289,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Castlevania: Dawn of Sorrow",
       "game_region": "USA",
       "base_name": "Metroid Prime Hunters",
@@ -265,6 +298,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Castlevania: Dawn of Sorrow",
       "game_region": "USA",
       "base_name": "Wario Ware: Touched",
@@ -273,6 +307,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Castlevania: Dawn of Sorrow",
       "game_region": "USA",
       "base_name": "The Legend of Zelda: Spirit Tracks US",
@@ -281,6 +316,7 @@
       "notes": "Also compatible with the playable Link patch: https://www.romhacking.net/hacks/7646/"
     },
     {
+      "rendersize": null,
       "game_name": "Castlevania: Order of Ecclesia",
       "game_region": "USA",
       "base_name": "Metroid Prime Hunters",
@@ -289,6 +325,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Castlevania: Order of Ecclesia",
       "game_region": "USA",
       "base_name": "Legend of Zelda: Spirit Tracks",
@@ -297,6 +334,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Castlevania: Order of Ecclesia",
       "game_region": "USA",
       "base_name": "Wario Ware: Touched",
@@ -305,6 +343,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Castlevania: Potrait of Ruin",
       "game_region": "USA",
       "base_name": "Metroid Prime Hunters",
@@ -313,6 +352,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Chibi-Robo: Park Patrol",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -321,6 +361,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Chrono Trigger",
       "game_region": "USA",
       "base_name": "Mario Kart DS",
@@ -329,6 +370,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Chuck E. Cheese's Party Games",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -337,6 +379,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Club Penguin: Elite Penguin Force v1.2",
       "game_region": "USA",
       "base_name": "New Super Mario Bros",
@@ -345,6 +388,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Clubhouse Games",
       "game_region": "EUR",
       "base_name": "Picross 3D",
@@ -353,6 +397,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Contra 4",
       "game_region": "USA",
       "base_name": "Metroid Prime Hunters",
@@ -361,6 +406,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Cooking Guide: Can't Decide What to Eat?",
       "game_region": "EUR",
       "base_name": "Picross 3D",
@@ -369,6 +415,7 @@
       "notes": "Microphone instructions seem to not work properly: the game picks up the voice, but can't understand the words, and this makes vocal advancing through the recipes impossible."
     },
     {
+      "rendersize": null,
       "game_name": "Cooking Mama",
       "game_region": "USA",
       "base_name": "The Legend of Zelda: Phantom Hourglass",
@@ -377,6 +424,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Cooking Mama 2: Dinner with Friends",
       "game_region": "USA",
       "base_name": "The Legend of Zelda: Phantom Hourglass",
@@ -385,6 +433,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Cooking Mama 3: Shop & Chop",
       "game_region": "USA",
       "base_name": "The Legend of Zelda: Phantom Hourglass",
@@ -393,6 +442,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Cory in the House",
       "game_region": "USA",
       "base_name": "New Super Mario Bros",
@@ -401,6 +451,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Crash Boom Bang!",
       "game_region": "USA",
       "base_name": "Kirby Mass Attack",
@@ -409,6 +460,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Crash of the Titans",
       "game_region": "EUR",
       "base_name": "Metroid Prime Hunters",
@@ -417,6 +469,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "CTGP Nitro",
       "game_region": "EUR",
       "base_name": "New Super Mario Bros.",
@@ -425,6 +478,7 @@
       "notes": "The game will boot but when you select single player it will crash the console"
     },
     {
+      "rendersize": null,
       "game_name": "CTGP Nitro",
       "game_region": "EUR",
       "base_name": "The Legend of Zelda Spirit Tracks",
@@ -433,6 +487,7 @@
       "notes": "The game will boot but when you select single player it will crash the console"
     },
     {
+      "rendersize": null,
       "game_name": "CTGP Nitro",
       "game_region": "EUR",
       "base_name": "Mario Kart DS",
@@ -441,6 +496,7 @@
       "notes": "The game will boot but when you select single player it will crash the console"
     },
     {
+      "rendersize": null,
       "game_name": "CTGP Nitro",
       "game_region": "USA",
       "base_name": "Mario Kart DS",
@@ -449,6 +505,7 @@
       "notes": "Is ROM Hack. Crashes when going into any menu option, but does allow you to create an emblem and confirm your nickname. After that, a crashed"
     },
     {
+      "rendersize": null,
       "game_name": "CTGP Nitro Release 1.1.0",
       "game_region": "USA",
       "base_name": "Mario Kart DS",
@@ -457,6 +514,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Culdcept DS",
       "game_region": "JPN",
       "base_name": "New Super Mario Bros.",
@@ -465,6 +523,7 @@
       "notes": "Will also work with the translation patch from https://www.romhacking.net/translations/2579"
     },
     {
+      "rendersize": null,
       "game_name": "Custom Robo",
       "game_region": "USA",
       "base_name": "The Legend of Zelda: Phantom Hourglass",
@@ -473,14 +532,7 @@
       "notes": "None"
     },
     {
-      "game_name": "Dementium II",
-      "game_region": "USA",
-      "base_name": "Metroid Prime Hunters",
-      "base_region": "USA",
-      "status": 0,
-      "notes": "White screen somehow. It worked fine first but its a white screen."
-    },
-    {
+      "rendersize": null,
       "game_name": "Dementium II",
       "game_region": "EUR",
       "base_name": "Metroid Prime Hunters",
@@ -489,6 +541,16 @@
       "notes": "White screen somehow. It worked fine first but its a white screen."
     },
     {
+      "rendersize": null,
+      "game_name": "Dementium II",
+      "game_region": "USA",
+      "base_name": "Metroid Prime Hunters",
+      "base_region": "USA",
+      "status": 0,
+      "notes": "White screen somehow. It worked fine first but its a white screen."
+    },
+    {
+      "rendersize": null,
       "game_name": "Diddy Kong Racing DS",
       "game_region": "USA",
       "base_name": "Kirby Mass Attack",
@@ -497,6 +559,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Dig Dug: Digging Strike",
       "game_region": "USA",
       "base_name": "Kirby Mass Attack",
@@ -505,6 +568,7 @@
       "notes": "Minor GFX glitches in cutscenes."
     },
     {
+      "rendersize": null,
       "game_name": "Digimon World DS",
       "game_region": "USA",
       "base_name": "Mario Kart DS",
@@ -513,6 +577,7 @@
       "notes": "Minor GFX glitches in cutscenes."
     },
     {
+      "rendersize": null,
       "game_name": "Digimon World Lost Evolution (English Patch)",
       "game_region": "JPN",
       "base_name": "Super Mario 64 DS ",
@@ -521,6 +586,7 @@
       "notes": "Crashes after first transition of the opening cutscene (black screen with music still playing indefinitely)"
     },
     {
+      "rendersize": null,
       "game_name": "Digimon World Lost Evolution (English Patch)",
       "game_region": "JPN",
       "base_name": "Legend of Zelda: Spirit Tracks",
@@ -529,6 +595,7 @@
       "notes": "Crashes after first transition of the opening cutscene (black screen with music still playing indefinitely) (Same issue as stated with other base ROM)"
     },
     {
+      "rendersize": null,
       "game_name": "Doctor Who: Evacuation Earth",
       "game_region": "EUR",
       "base_name": "New Super Mario Bros ",
@@ -537,6 +604,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Doodle Jump",
       "game_region": "USA",
       "base_name": "Picross 3D",
@@ -545,6 +613,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Dora the Explorer Saves the Snow Princess",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -553,6 +622,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Dragon Ball Z: Harakaranu Densetsu",
       "game_region": "USA",
       "base_name": "Super Mario 64 DS",
@@ -561,6 +631,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Dragon Ball: Origins",
       "game_region": "USA",
       "base_name": "Mario Kart DS",
@@ -569,6 +640,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Dragon Quest IV: Chapters of the Chosen",
       "game_region": "USA",
       "base_name": "Yoshi Touch & Go",
@@ -577,6 +649,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Dragon Quest IV: Chapters of the Chosen",
       "game_region": "USA",
       "base_name": "Legend of Zelda: Spirit Tracks",
@@ -585,6 +658,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Dragon Quest IX: Sentinels of the starry Skies",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -593,6 +667,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Dragon Quest Monsters: Joker 2",
       "game_region": "USA",
       "base_name": "The Legend of Zelda: Spirit Tracks US",
@@ -601,6 +676,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Dragon Quest V: Hand of the Heavenly Blade",
       "game_region": "USA",
       "base_name": "Yoshi Touch & Go",
@@ -609,6 +685,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Dragon Quest VI: Realms of Revelation",
       "game_region": "USA",
       "base_name": "Kirby's Squeak Squad",
@@ -617,6 +694,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Drawn to Life!",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -625,6 +703,7 @@
       "notes": "It runs but when you get into the level, the background when it's suppost to move it turns black."
     },
     {
+      "rendersize": null,
       "game_name": "Drawn to Life!",
       "game_region": "USA",
       "base_name": "Super Mario 64 DS",
@@ -633,6 +712,7 @@
       "notes": "It runs but when you get into the level, the background when it's suppost to move it turns black."
     },
     {
+      "rendersize": null,
       "game_name": "Drawn to Life!",
       "game_region": "USA",
       "base_name": "WarioWare Touch",
@@ -641,6 +721,7 @@
       "notes": "It runs but when you get into the level, the background when it's suppost to move it turns black."
     },
     {
+      "rendersize": null,
       "game_name": "Drawn to Life!: Collection",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -649,6 +730,7 @@
       "notes": "It runs but when you get into the level, the background when it's suppost to move it turns black."
     },
     {
+      "rendersize": null,
       "game_name": "Drawn to Life!: Collection",
       "game_region": "USA",
       "base_name": "Super Mario 64 DS",
@@ -657,6 +739,7 @@
       "notes": "It runs but when you get into the level, the background when it's suppost to move it turns black."
     },
     {
+      "rendersize": null,
       "game_name": "Drawn to Life!: Collection",
       "game_region": "USA",
       "base_name": "WarioWare Touch",
@@ -665,6 +748,7 @@
       "notes": "It runs but when you get into the level, the background when it's suppost to move it turns black."
     },
     {
+      "rendersize": null,
       "game_name": "DTM Race Driver 3: Create & Race",
       "game_region": "EUR",
       "base_name": "Picross 3D",
@@ -673,6 +757,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "eCDP McDonalds Training Game",
       "game_region": "JPN",
       "base_name": "WarioWare: Touched",
@@ -681,6 +766,7 @@
       "notes": "You're gonna want Mario Kart DS for the serial number obtainer"
     },
     {
+      "rendersize": null,
       "game_name": "Electronic Arts, Sudoku",
       "game_region": "USA",
       "base_name": "Kirby Squeak Squad",
@@ -689,6 +775,7 @@
       "notes": "Black screen."
     },
     {
+      "rendersize": null,
       "game_name": "Electroplankton",
       "game_region": "USA",
       "base_name": "Metroid Prime Hunters US",
@@ -697,6 +784,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Elite Beat Agents",
       "game_region": "USA",
       "base_name": "Yoshi Touch & Go",
@@ -705,6 +793,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Elite Beat Agents",
       "game_region": "USA",
       "base_name": "Mario Kart DS",
@@ -713,6 +802,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Enchanted Folk and the School of Wizardy",
       "game_region": "USA",
       "base_name": "Mew Super Mario Bros.",
@@ -721,6 +811,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Ermii Kart DS: Legacy Edition",
       "game_region": "USA",
       "base_name": "Mario Kart DS",
@@ -729,6 +820,7 @@
       "notes": "Gets past the in-game screen, then crashes and no sound."
     },
     {
+      "rendersize": null,
       "game_name": "Etrian Odyssey",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -737,6 +829,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Etrian Odyssey II",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -745,6 +838,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Etrian Odyssey III",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -753,6 +847,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Feel the Magic XY/XX",
       "game_region": "USA",
       "base_name": "Metroid Prime Hunters",
@@ -761,6 +856,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "FIFA 10",
       "game_region": "USA",
       "base_name": "Picross 3D",
@@ -769,6 +865,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Final Fantasy III",
       "game_region": "USA",
       "base_name": "Kirby Squeak Squad",
@@ -777,6 +874,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Final Fantasy IV",
       "game_region": "USA",
       "base_name": "Yoshi Touch & Go",
@@ -785,6 +883,7 @@
       "notes": "Minor graphical glitches in screen transitions."
     },
     {
+      "rendersize": null,
       "game_name": "Final Fantasy Tactics A2: Grimoire of the Rift",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -793,6 +892,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Final Fantasy XII: Revenant Wings",
       "game_region": "USA",
       "base_name": "Zelda Phantom Hourglass",
@@ -801,6 +901,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Final Fantasy: The 4 Heroes of Light",
       "game_region": "USA",
       "base_name": "Brain Age: Train Your Brain in Minutes a Day!",
@@ -809,6 +910,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Fire Emblem: Heroes of Light and Shadow",
       "game_region": "JPN",
       "base_name": "New Super Mario Bros.",
@@ -817,6 +919,7 @@
       "notes": "Shows a white screen."
     },
     {
+      "rendersize": null,
       "game_name": "Fire Emblem: Shadow Dragon - Full Content Patch",
       "game_region": "USA",
       "base_name": "The Legend of Zelda: Spirit Tracks US",
@@ -825,6 +928,7 @@
       "notes": "Compatible with the full content patch https://www.romhacking.net/hacks/4054/"
     },
     {
+      "rendersize": null,
       "game_name": "Flower, Sun, and Rain",
       "game_region": "EUR",
       "base_name": "Mario Kart DS",
@@ -833,6 +937,7 @@
       "notes": "Tested briefly, runs as it should from what i could tell, would recommend as a pre-NMH suda51 title with vibes unmatched by any other on the DS"
     },
     {
+      "rendersize": null,
       "game_name": "Freshly Picked! Tingle's Rosy Rupeeland",
       "game_region": "EUR",
       "base_name": "Kirby Mass Attack",
@@ -841,6 +946,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Front Mission DS",
       "game_region": "JPN",
       "base_name": "New Super Mario Bros.",
@@ -849,6 +955,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Ghost Trick: Phantom Detective",
       "game_region": "EUR",
       "base_name": "Fire Emblem: Shadow Dragon",
@@ -857,6 +964,7 @@
       "notes": "A couple of extremely minor graphical glithces: 1 pixel high line at the top of the touch screen at certain points and a whole screen mess flashes for a split second just before the animation for when you transport between areas."
     },
     {
+      "rendersize": null,
       "game_name": "Giana Sisters DS",
       "game_region": "EUR",
       "base_name": "Metroid Prime Hunters",
@@ -865,6 +973,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Golden Sun: Dark Dawn",
       "game_region": "EUR",
       "base_name": "Pokémon Mystery Dungeon: Explorers of the Sky",
@@ -873,6 +982,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Gormiti: The Lords of Nature!",
       "game_region": "EUR",
       "base_name": "New Super Mario Bros:",
@@ -881,6 +991,7 @@
       "notes": "Soft-locks Wii U."
     },
     {
+      "rendersize": null,
       "game_name": "Gormiti: The Lords of Nature!",
       "game_region": "EUR",
       "base_name": "New Super Mario Bros!",
@@ -889,6 +1000,7 @@
       "notes": "Soft-locks Wii U."
     },
     {
+      "rendersize": null,
       "game_name": "Grand Theft Auto: Chinatown Wars",
       "game_region": "USA",
       "base_name": "Super Mario 64 DS",
@@ -897,6 +1009,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Grand Theft Auto: Chinatown Wars",
       "game_region": "USA",
       "base_name": ": Mario Kart DS US \\ Yoshi's Island US \\ Legend of Zelda: Spirit Tracks US \\ New Super Mario Bros. US \\ Super Mario 64 DS US  \\ Love Plus DS",
@@ -905,6 +1018,7 @@
       "notes": "Same result on every injection attempt. Game loads and cutscenes run normally. NPC and player models work fine, but there are invisible walls, cars, buildings, roads and etc, making it almost unplayable"
     },
     {
+      "rendersize": null,
       "game_name": "Grand Theft Auto: Chinatown Wars",
       "game_region": "USA",
       "base_name": "Super Mario 64 DS",
@@ -913,6 +1027,7 @@
       "notes": "User listed this as doesn't work, but wrote 'Boots fine, but missing assets'"
     },
     {
+      "rendersize": null,
       "game_name": "Guinness World Records: The Video Game",
       "game_region": "USA",
       "base_name": "Kirby Mass Attack",
@@ -921,6 +1036,7 @@
       "notes": "On some menus, the touch screen and upper screen will switch. Touch screen is still functional when switched."
     },
     {
+      "rendersize": null,
       "game_name": "Gunpey DS",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -929,6 +1045,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Gyakuten Kenji 2",
       "game_region": "JPN",
       "base_name": "Fire Emblem: Shadow DRagon",
@@ -937,6 +1054,7 @@
       "notes": "Works until the end of case 5 where you have to use the microphone to blow fingerprint powder away. The animation for blowing is there, but it doesn't get rid of it."
     },
     {
+      "rendersize": null,
       "game_name": "Hajime No Ippo the Fighting",
       "game_region": "JPN",
       "base_name": "New Super Mario Bros.",
@@ -945,6 +1063,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Harry Potter and the Order of the Phoenix",
       "game_region": "EUR",
       "base_name": "New Super Mario Bros.",
@@ -953,6 +1072,7 @@
       "notes": "Has graphical glitches during parts where people talk to each other, text readable and not game breaking. Objects (including people) can be seen through walls, confusing at times."
     },
     {
+      "rendersize": null,
       "game_name": "Harvest Moon DS",
       "game_region": "EUR",
       "base_name": "Fire Emblem: Shadow Dragon",
@@ -961,6 +1081,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Harvest Moon DS: Island of Happiness",
       "game_region": "USA",
       "base_name": "Fire Emblem: Shadow Dragon",
@@ -969,6 +1090,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Henry Hatsworth in the Puzzling Adventure",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -977,6 +1099,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Hero's Saga Laevatein Tactics",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -985,6 +1108,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Hotel Dusk: Room 215",
       "game_region": "USA",
       "base_name": "Mario Hoops 3-on-3",
@@ -993,6 +1117,7 @@
       "notes": "Change the fold_on_pause following setting in the configuration_cafe.json to true to solve the puzzle with Mila later in the game (pause the game with ZR or Home to 'close' the emulated DS)."
     },
     {
+      "rendersize": null,
       "game_name": "House M.D.-The Official Game",
       "game_region": "EUR",
       "base_name": "Super Mario 64 DS",
@@ -1001,6 +1126,7 @@
       "notes": "I only did it cuz i thought it was funny lol"
     },
     {
+      "rendersize": null,
       "game_name": "Ice Age 3: Dawn of the Dinosaurs",
       "game_region": "USA",
       "base_name": "Mario Kart DS",
@@ -1009,6 +1135,7 @@
       "notes": "Game doesn't start."
     },
     {
+      "rendersize": null,
       "game_name": "Ice Age 4: Continental Drift: Arctic Games",
       "game_region": "USA",
       "base_name": "Super Mario 64 DS",
@@ -1017,6 +1144,7 @@
       "notes": "White screen."
     },
     {
+      "rendersize": null,
       "game_name": "Inazuma Eleven",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -1025,6 +1153,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Infinite Space",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -1033,6 +1162,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "InuYasha: Secret of the Divine",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -1041,6 +1171,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Irozuki Tingle no Koi no Balloon Trip",
       "game_region": "JPN",
       "base_name": "Picross 3D",
@@ -1049,6 +1180,7 @@
       "notes": "Will also work with the translation patch from https://www.romhacking.net/translations/3376/"
     },
     {
+      "rendersize": null,
       "game_name": "Ivy the Kiwi?",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -1057,6 +1189,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Izuna 2: The Unemployed Ninja Returns",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -1065,6 +1198,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Izuna: Legend of the Unemployed Ninja",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -1073,6 +1207,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Jump Ultimate Stars",
       "game_region": "JPN",
       "base_name": "New Super Mario Bros.",
@@ -1081,6 +1216,7 @@
       "notes": "Will also work with the translation patch from https://www.romhacking.net/translations/1636/"
     },
     {
+      "rendersize": null,
       "game_name": "Ketsui Death Label",
       "game_region": "JPN",
       "base_name": "Yoshi Touch & Go",
@@ -1089,6 +1225,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Kingdom Hearts 358/2 Days",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -1097,6 +1234,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Kingdom Hearts 358/2 Days",
       "game_region": "USA",
       "base_name": "Legend of Zelda: Spirit Tracks",
@@ -1105,6 +1243,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Kingdom Hearts 358/2 Days",
       "game_region": "USA",
       "base_name": "Metroid Prime Hunters",
@@ -1113,6 +1252,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Kingdom Hearts RE: Coded",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -1121,6 +1261,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Kirby Super Star Ultra",
       "game_region": "USA",
       "base_name": "Super Mario 64 DS",
@@ -1129,6 +1270,7 @@
       "notes": "Blank ini. Game runs perfectly for Spring Breeze, but then the controls permanently lock up aftewards when entering the main menu again."
     },
     {
+      "rendersize": null,
       "game_name": "Kirby Super Star Ultra",
       "game_region": "USA",
       "base_name": "Yoshi Toch & Go",
@@ -1137,6 +1279,7 @@
       "notes": "Cut-scenes play way too fast. Controls lock up when new games are unlocked."
     },
     {
+      "rendersize": null,
       "game_name": "Knights in the Nightmare",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -1145,6 +1288,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Kung Fu Panda",
       "game_region": "USA",
       "base_name": "Picross",
@@ -1153,6 +1297,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Last Window: The Secret of Cape West",
       "game_region": "EUR",
       "base_name": "Kirby Squeak Squad",
@@ -1161,6 +1306,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Legay of Ys: Books I && II",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -1169,6 +1315,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Lego Battles",
       "game_region": "USA",
       "base_name": "Mario Kart DS",
@@ -1177,6 +1324,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Lego Indiana Jones 2: The Adventure Continues",
       "game_region": "EUR",
       "base_name": "WarioWare: Touched! ",
@@ -1185,14 +1333,7 @@
       "notes": "Invisible UI Elements in title screen until ZR (Suspend Menu) is opened but most are still invisible do this a lot to get past the title screen, after that it works perfectly fine."
     },
     {
-      "game_name": "Lego Star Wars: The Complete Saga",
-      "game_region": "USA",
-      "base_name": "Yoshi's Island DS",
-      "base_region": "USA",
-      "status": 1,
-      "notes": "UI on main menu and in between menus flickers a bit, but otherwise everything is fine"
-    },
-    {
+      "rendersize": null,
       "game_name": "Lego Star Wars: The Complete Saga",
       "game_region": "EUR",
       "base_name": "WarioWare: Touched! ",
@@ -1201,6 +1342,16 @@
       "notes": "Flickering UI Elements in the Title Screen, After going through that it works perfectly fine."
     },
     {
+      "rendersize": null,
+      "game_name": "Lego Star Wars: The Complete Saga",
+      "game_region": "USA",
+      "base_name": "Yoshi's Island DS",
+      "base_region": "USA",
+      "status": 1,
+      "notes": "UI on main menu and in between menus flickers a bit, but otherwise everything is fine"
+    },
+    {
+      "rendersize": null,
       "game_name": "Lufia: Curse of the Sinistrals",
       "game_region": "USA",
       "base_name": "The Legend of Zelda: Spirit Tracks",
@@ -1209,6 +1360,7 @@
       "notes": "Works perfectly, surprisingly fun game"
     },
     {
+      "rendersize": null,
       "game_name": "Mario & Luigi Bowser's Inside Story",
       "game_region": "USA",
       "base_name": "Super Mario 64 DS",
@@ -1217,6 +1369,7 @@
       "notes": "A few graphical errors like screen flickering, and the occasional soft-lock. Use Restore Points often. (Requires more testing). Playable."
     },
     {
+      "rendersize": null,
       "game_name": "Mario & Luigi Bowser's Inside Story",
       "game_region": "USA",
       "base_name": "Mario Kart DS",
@@ -1225,6 +1378,7 @@
       "notes": "Anti-Piracy kicks in when you get to the first Bowser, the game just deletes all the sprites, and can't do anything."
     },
     {
+      "rendersize": null,
       "game_name": "Mario & Luigi Bowser's Inside Story",
       "game_region": "USA",
       "base_name": "Animal Crossing Wild World",
@@ -1233,6 +1387,7 @@
       "notes": "Anti-Piracy kicks in when you get to the first Bowser, the game just deletes all the sprites, and can't do anything."
     },
     {
+      "rendersize": null,
       "game_name": "Mario & Luigi Bowser's Inside Story (Anti-Piracy Patch Applied)",
       "game_region": "USA",
       "base_name": "Super Mario 64 DS",
@@ -1241,6 +1396,7 @@
       "notes": "Some strange graphical issues on occasion, and bad loading times, still playable though."
     },
     {
+      "rendersize": null,
       "game_name": "Mario & Luigi Bowser's Inside Story (Patched with Xdelta)",
       "game_region": "USA",
       "base_name": "The Legend of Zelda: Spirit Tracks",
@@ -1249,6 +1405,7 @@
       "notes": "Long load times, but playable."
     },
     {
+      "rendersize": null,
       "game_name": "Mario & Luigi: Bowsers Inside Story",
       "game_region": "USA",
       "base_name": "Mario Hoops 3-on-3",
@@ -1257,6 +1414,7 @@
       "notes": "Fixes softlock bug in Bowser's stomach. HOwever, the game hard-locks at the Midbus Battle in Cavi Cape."
     },
     {
+      "rendersize": null,
       "game_name": "Mario and Sonic at the Olympic Winter Games (Sochi 2010)",
       "game_region": "USA",
       "base_name": "Yoshi's Island DS",
@@ -1265,6 +1423,7 @@
       "notes": "Story mode Cutscene visuals are glitched, but you can mash the a button through them to get to the gameplay Edit: the visuals for ski jump and moguls do not work. This halts story progression right at the start since you can not unlock Tails. That is so weird. I’ve tried pretty much every other sport and only the 3D skiing ones don’t  work. Might have something to do with the camera, since the cutscenes didn’t work either. Same results with loadiine. However, the game works just fine with NDS2WiiU"
     },
     {
+      "rendersize": null,
       "game_name": "Mario Hoops 3-on-3",
       "game_region": "EUR",
       "base_name": "Picross 3D",
@@ -1273,6 +1432,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Mario Kart DS",
       "game_region": "EUR",
       "base_name": "Mario Kart DS",
@@ -1281,6 +1441,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Mario Kart DS Deluxe 0.1",
       "game_region": "USA",
       "base_name": "New Super Mario Bros",
@@ -1289,6 +1450,7 @@
       "notes": "Unsure if Loadiine or Wup Installable. The frames sometimes drop."
     },
     {
+      "rendersize": null,
       "game_name": "Marvel Nemesis: Rise of the Imperfects",
       "game_region": "USA",
       "base_name": "Mario Kart DS",
@@ -1297,6 +1459,7 @@
       "notes": "I did not find this game enjoyable."
     },
     {
+      "rendersize": null,
       "game_name": "Meccha Taiko no Tatsujin DS - 7tsu no Shima no Daibouken",
       "game_region": "JPN",
       "base_name": "Yoshi Touch & Go",
@@ -1305,6 +1468,7 @@
       "notes": "Other base roms I tried had different issues, from flickering, black lower screen and soft lock on exit. But this combination has worked fine so far."
     },
     {
+      "rendersize": null,
       "game_name": "Mega Man Star Force 2: Zerker x Saurian ",
       "game_region": "USA",
       "base_name": "Mario Kart DS US",
@@ -1313,6 +1477,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Mega Man Star Force 3: Black Ace ",
       "game_region": "USA",
       "base_name": "Mario Kart DS US",
@@ -1321,6 +1486,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Mega Man Star Force Dragon",
       "game_region": "USA",
       "base_name": "Mario Kart DS US",
@@ -1329,6 +1495,16 @@
       "notes": "None"
     },
     {
+      "rendersize": "1x",
+      "game_name": "MegaMan Battle Network Operate Star Force",
+      "game_region": "JPN",
+      "base_name": "Mario Kart DS",
+      "base_region": "USA",
+      "status": 2,
+      "notes": "This is patched with the fan translation (https://forums.therockmanexezone.com/rockman-exe-operate-shooting-star-translation-proj-t4427.html) of the game Rockman EXE Operate Shooting Star. (UWUVCI Version: 3.200.1)"
+    },
+    {
+      "rendersize": null,
       "game_name": "Megaman Zero Collection",
       "game_region": "USA",
       "base_name": "Yoshi Touch & Go",
@@ -1337,6 +1513,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Megaman ZX",
       "game_region": "EUR",
       "base_name": "Yoshi Touch & Go",
@@ -1345,6 +1522,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Megaman ZX Advent",
       "game_region": "EUR",
       "base_name": "Yoshi Touch & Go",
@@ -1353,6 +1531,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Megami Ibunroku Devil Survivor",
       "game_region": "JPN",
       "base_name": "Mario Kart DS ",
@@ -1361,6 +1540,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Metal Slug 7",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -1369,6 +1549,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Miles Edgeworth: Ace Attorney Investigations",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -1377,6 +1558,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Momo Waliou Zhizao",
       "game_region": "China",
       "base_name": "WarioWare: Touched",
@@ -1385,6 +1567,7 @@
       "notes": "Chinese version of WarioWare: Touched! just remember to change hex value at 1D from 80 to 00 to bypass the ONLY FOR iQue DS screen."
     },
     {
+      "rendersize": null,
       "game_name": "Moon",
       "game_region": "EUR",
       "base_name": "Picross 3D",
@@ -1393,6 +1576,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Namco Museum DS",
       "game_region": "USA",
       "base_name": "Kirby Mass Attack",
@@ -1401,6 +1585,7 @@
       "notes": "Minor SFX and GFX issues."
     },
     {
+      "rendersize": null,
       "game_name": "Nanostray",
       "game_region": "USA",
       "base_name": "Mario and Luigi: Partners in Time",
@@ -1409,6 +1594,7 @@
       "notes": "Only 3D objects are rendered."
     },
     {
+      "rendersize": null,
       "game_name": "Need For Speed: Most Wanted",
       "game_region": "USA",
       "base_name": "Mario and Luigi: Partners in Time",
@@ -1417,6 +1603,7 @@
       "notes": "In-game locks up console."
     },
     {
+      "rendersize": null,
       "game_name": "Need For Speed: Undercover",
       "game_region": "EUR",
       "base_name": "Picross 3D",
@@ -1425,6 +1612,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Need For Speed: Undercover 2",
       "game_region": "EUR",
       "base_name": "Picross 3D",
@@ -1433,6 +1621,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Neighbours From Hell",
       "game_region": "EUR",
       "base_name": "Picross 3D",
@@ -1441,6 +1630,7 @@
       "notes": "Most of the textures don't load and stay black."
     },
     {
+      "rendersize": null,
       "game_name": "Nervous Brickdown",
       "game_region": "EUR",
       "base_name": "Picross 3D",
@@ -1449,6 +1639,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "New Chaoji Maliou Xiongdi",
       "game_region": "China",
       "base_name": "New Super Mario Bros.",
@@ -1457,6 +1648,7 @@
       "notes": "Chinese version of New Super Mario Bros. Just remember to change the hex value at 1D from 80 to 00 to bypass the ONLY FOR iQue DS screen."
     },
     {
+      "rendersize": null,
       "game_name": "New Super Mario Bros 3 DS",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -1465,6 +1657,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "New Super Mario Bros DS",
       "game_region": "EUR",
       "base_name": "Super Mario 64 DS",
@@ -1473,6 +1666,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "New Super Mario Bros. U DS",
       "game_region": "USA",
       "base_name": "New Super Mario Bros. DS",
@@ -1481,14 +1675,7 @@
       "notes": "Mod created by Skylander Productions. Edit the \"configuration_cafe.json\" to increase the brightness."
     },
     {
-      "game_name": "Newer Super Mario Bros DS",
-      "game_region": "USA",
-      "base_name": "Yoshi's Island DS",
-      "base_region": "USA",
-      "status": 2,
-      "notes": "Romhack from: https://www.romhacking.net/hacks/3892/"
-    },
-    {
+      "rendersize": null,
       "game_name": "Newer Super Mario Bros DS",
       "game_region": "EUR",
       "base_name": "Yoshi's Island",
@@ -1497,6 +1684,16 @@
       "notes": "Get the romhack here: https://www.romhacking.net/hacks/3892/. Use this Patch (https://drive.google.com/file/d/1-0P7es7PX8YTc6bBoMBivjdBfGo5m5a2/view) on the Rom before Injecting."
     },
     {
+      "rendersize": null,
+      "game_name": "Newer Super Mario Bros DS",
+      "game_region": "USA",
+      "base_name": "Yoshi's Island DS",
+      "base_region": "USA",
+      "status": 2,
+      "notes": "Romhack from: https://www.romhacking.net/hacks/3892/"
+    },
+    {
+      "rendersize": null,
       "game_name": "Ni No Kuni: The Jet Black Manage / Ni no Kuni: Shikkoku no Madoushi",
       "game_region": "EUR",
       "base_name": "The Legend of Zelda: Spirit Tracks",
@@ -1505,6 +1702,7 @@
       "notes": "Boots to blackscreen. Wii U freezes on booting the game."
     },
     {
+      "rendersize": null,
       "game_name": "Nicktoons: Attack of the Toybots!",
       "game_region": "USA",
       "base_name": "Kirby Mass Attack",
@@ -1513,6 +1711,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Nicktoons: Battle for Volcano Island",
       "game_region": "USA",
       "base_name": "WarioWare: Touched!",
@@ -1521,6 +1720,7 @@
       "notes": "This is my favorite DS game of the year. The Japanese ROM (SpongeBob to Nakama-tachi) has also been tested, and it works. It should be ported to other platforms once its decompiled!!"
     },
     {
+      "rendersize": null,
       "game_name": "Nictoons MLB",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -1529,6 +1729,7 @@
       "notes": "Voice clips stutter at last second from each clip."
     },
     {
+      "rendersize": null,
       "game_name": "Nintendo Presents: Style Boutique",
       "game_region": "EUR",
       "base_name": "Mario Kart DS",
@@ -1537,6 +1738,7 @@
       "notes": "Region unknown."
     },
     {
+      "rendersize": null,
       "game_name": "Okamiden",
       "game_region": "USA",
       "base_name": "Mario Kart DS",
@@ -1545,6 +1747,7 @@
       "notes": "Touch seems to be invisible."
     },
     {
+      "rendersize": null,
       "game_name": "Ontamarama",
       "game_region": "USA",
       "base_name": "Kirby Mass Attack",
@@ -1553,6 +1756,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Osu! Tatakae! Ouendan",
       "game_region": "JPN",
       "base_name": "Metroid Prime Hunters",
@@ -1561,6 +1765,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Pac-Pix",
       "game_region": "USA",
       "base_name": "Kirby Mass Attack",
@@ -1569,6 +1774,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Panzer Tactics DS",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -1577,6 +1783,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Peggle Dual Shot",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -1585,6 +1792,7 @@
       "notes": "I found minor graphical glitches in menus but nothing game-breaking."
     },
     {
+      "rendersize": null,
       "game_name": "Phantasy Star Zero",
       "game_region": "USA",
       "base_name": "Kirby Squeak Squad",
@@ -1593,6 +1801,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Phineas & Ferb",
       "game_region": "USA",
       "base_name": "Picross",
@@ -1601,6 +1810,7 @@
       "notes": "Game crashes when trying to start a new game :("
     },
     {
+      "rendersize": null,
       "game_name": "Phoenix Wright - Ace Attorney (de,es,it)",
       "game_region": "EUR",
       "base_name": "The Legend of Zelda: Spirit Tracks",
@@ -1609,6 +1819,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Phoenix Wright: Ace Attorney",
       "game_region": "USA",
       "base_name": "Metroid Prime Hunters",
@@ -1617,6 +1828,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Phoenix Wright: Ace Attorney - Justice For All",
       "game_region": "USA",
       "base_name": "Metroid Prime Hunters",
@@ -1625,6 +1837,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Phoenix Wright: Ace Attorney - Trials and Tribulations",
       "game_region": "USA",
       "base_name": "Metroid Prime Hunters",
@@ -1633,14 +1846,7 @@
       "notes": "None"
     },
     {
-      "game_name": "PictoChat",
-      "game_region": "USA",
-      "base_name": "New Super Mario Bros.",
-      "base_region": "USA",
-      "status": 0,
-      "notes": "Region unknown. White screen. Won't boot."
-    },
-    {
+      "rendersize": null,
       "game_name": "PictoChat",
       "game_region": "Any",
       "base_name": "New Super Mario Bros.",
@@ -1649,6 +1855,16 @@
       "notes": "White screen. Won't boot."
     },
     {
+      "rendersize": null,
+      "game_name": "PictoChat",
+      "game_region": "USA",
+      "base_name": "New Super Mario Bros.",
+      "base_region": "USA",
+      "status": 0,
+      "notes": "Region unknown. White screen. Won't boot."
+    },
+    {
+      "rendersize": null,
       "game_name": "Planet Puzzle LeagueB",
       "game_region": "USA",
       "base_name": "Dr. Kawashima's Brain Training: How Old Is Your Brain?",
@@ -1657,6 +1873,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Plants VS. Zombies",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -1665,6 +1882,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Pokémon Black Version",
       "game_region": "USA",
       "base_name": "Kirby Squeak Squad",
@@ -1673,6 +1891,7 @@
       "notes": "Does not load and locks the console on a black screen."
     },
     {
+      "rendersize": null,
       "game_name": "Pokémon Black Version 2",
       "game_region": "USA",
       "base_name": "Yoshi Touch & Go",
@@ -1681,6 +1900,7 @@
       "notes": "Does not load and locks the console on a black screen."
     },
     {
+      "rendersize": null,
       "game_name": "Pokémon Conquest",
       "game_region": "USA",
       "base_name": "Metroid Prime Hunters",
@@ -1689,6 +1909,7 @@
       "notes": "Does not load and locks hte console on a black screen."
     },
     {
+      "rendersize": null,
       "game_name": "Pokémon Diamond",
       "game_region": "USA",
       "base_name": "Yoshi's Island",
@@ -1697,6 +1918,7 @@
       "notes": "Minor GFX glitches in ground."
     },
     {
+      "rendersize": null,
       "game_name": "Pokémon Diamond",
       "game_region": "USA",
       "base_name": "Mario Kart DS",
@@ -1705,6 +1927,7 @@
       "notes": "Minor GFX glitches in ground."
     },
     {
+      "rendersize": null,
       "game_name": "Pokémon Diamond & Pearl GameStop Deoxys Distribution",
       "game_region": "USA",
       "base_name": "Yoshi's Island",
@@ -1713,6 +1936,7 @@
       "notes": "Will only work if the clock is set to either June 20 or 27, 2008. Also, it can't distribute as the Wii U can't connect to ther DS & 3DS systems."
     },
     {
+      "rendersize": null,
       "game_name": "Pokémon HeartGold",
       "game_region": "USA",
       "base_name": "Yoshi's Island",
@@ -1721,6 +1945,7 @@
       "notes": "Minor GFX glitches in ground."
     },
     {
+      "rendersize": null,
       "game_name": "Pokémon Pearl",
       "game_region": "USA",
       "base_name": "Mario and Luigi: Partners in Time",
@@ -1729,6 +1954,16 @@
       "notes": "Minor GFX glitches in ground."
     },
     {
+      "rendersize": null,
+      "game_name": "Pokémon Platinum",
+      "game_region": "EUR",
+      "base_name": "Legend of Zelda: Spirit Tracks",
+      "base_region": "USA",
+      "status": 2,
+      "notes": "None"
+    },
+    {
+      "rendersize": null,
       "game_name": "Pokémon Platinum",
       "game_region": "USA",
       "base_name": "Yoshi's Island",
@@ -1737,6 +1972,7 @@
       "notes": "Minor GFX glitches in ground."
     },
     {
+      "rendersize": null,
       "game_name": "Pokémon Platinum",
       "game_region": "USA",
       "base_name": "Yoshi's Island",
@@ -1745,14 +1981,7 @@
       "notes": "Online compatibility list for general VC injections claims Platinum has graphical issues. They are not present on this build. Game renders perfectly fine."
     },
     {
-      "game_name": "Pokémon Platinum",
-      "game_region": "EUR",
-      "base_name": "Legend of Zelda: Spirit Tracks",
-      "base_region": "USA",
-      "status": 2,
-      "notes": "None"
-    },
-    {
+      "rendersize": null,
       "game_name": "Pokémon SoulSilver",
       "game_region": "USA",
       "base_name": "Yoshi's Island",
@@ -1761,6 +1990,7 @@
       "notes": "Minor GFX glitches in ground."
     },
     {
+      "rendersize": null,
       "game_name": "Pokémon StormSilver v1.1 (Rom Hack)",
       "game_region": "USA",
       "base_name": "Mario Kart DS",
@@ -1769,6 +1999,7 @@
       "notes": "Character + Pokémon graphical glitches can happen in hubworld often but nothing game breaking."
     },
     {
+      "rendersize": null,
       "game_name": "Polarium",
       "game_region": "USA",
       "base_name": "Metroid Prime Hunters",
@@ -1777,6 +2008,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Power Rangers: Super Legends",
       "game_region": "USA",
       "base_name": "Mario Hoops 3-on-3",
@@ -1785,6 +2017,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Powerful Golf",
       "game_region": "JPN",
       "base_name": "Mario Kart DS ",
@@ -1793,6 +2026,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Professor Layton and Pandoras Box",
       "game_region": "EUR",
       "base_name": "Yoshi Touch & Go",
@@ -1801,6 +2035,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Professor Layton and The Curious Village",
       "game_region": "EUR",
       "base_name": "Yoshi Touch & Go",
@@ -1809,6 +2044,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Professor Layton and the Last Specter",
       "game_region": "USA",
       "base_name": "Mario Kart DS",
@@ -1817,6 +2053,7 @@
       "notes": "Use DS-Scene ROM Tool to Anti-Piracy Patch the game, otherwise the first puzzle cannot be solved."
     },
     {
+      "rendersize": null,
       "game_name": "Professor Layton and The Lost Future",
       "game_region": "EUR",
       "base_name": "Yoshi Touch & Go",
@@ -1825,6 +2062,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Professor Layton and The Lost Spectre's Call",
       "game_region": "EUR",
       "base_name": "Yoshi Touch & Go",
@@ -1833,6 +2071,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Professor Layton and The Spectre's Call",
       "game_region": "EUR",
       "base_name": "Zelda Spirit Tracks",
@@ -1841,6 +2080,7 @@
       "notes": "When you Submit during the first puzzle it just brings you back to the start of the puzzle, thereby trapping you in an infinite loop, game works on melonDS, so likely an issue with the Wii U's Emulator, might try different Base Rom later"
     },
     {
+      "rendersize": null,
       "game_name": "Professor Layton und die Schatulle der Pandora",
       "game_region": "EUR",
       "base_name": "The Legend of Zelda: Spirit Tracks",
@@ -1849,6 +2089,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Professor Layton und die Verlorene Zukunft",
       "game_region": "EUR",
       "base_name": "The Legend of Zelda: Spirit Tracks",
@@ -1857,6 +2098,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Puchi Puchi Virus",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -1865,6 +2107,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Puyo Puyo 15th Anniversary",
       "game_region": "JPN",
       "base_name": "New Super Mario Bros.",
@@ -1873,6 +2116,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Puyo Puyo 7",
       "game_region": "JPN",
       "base_name": "New Super Mario Bros.",
@@ -1881,6 +2125,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Puyo Puyo Fever",
       "game_region": "JPN",
       "base_name": "Kirby Mass Attack",
@@ -1889,6 +2134,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Puyo Puyo Fever",
       "game_region": "USA",
       "base_name": "Kirby Mass Attack",
@@ -1897,6 +2143,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Puzzle Quest - Challenge of the Warlords",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -1905,6 +2152,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Radiant Historia",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -1913,6 +2161,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Ragnarok",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -1921,6 +2170,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Resident Evil Deadly Silence",
       "game_region": "EUR",
       "base_name": "The Legend of Zelda: Spirit Tracks",
@@ -1929,6 +2179,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Resident Evil Deadly Silence",
       "game_region": "USA",
       "base_name": "Mario Kart DS",
@@ -1937,6 +2188,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Retro Game Challenge",
       "game_region": "USA",
       "base_name": "Yoshi Touch & Go",
@@ -1945,6 +2197,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Retro Game Challenge 2",
       "game_region": "JPN",
       "base_name": "New Super Mario Bros.",
@@ -1953,6 +2206,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Rhapsody - A Music Adventure",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -1961,6 +2215,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Rhythm Heaven",
       "game_region": "USA",
       "base_name": "Dr. Kawashima's Brain Training: How Old Is Your Brain?",
@@ -1969,6 +2224,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Rhythm Heaven",
       "game_region": "USA",
       "base_name": "Dr. Kawashima's Brain Training: How Old Is Your Brain?",
@@ -1977,6 +2233,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Rondo of Swords",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -1985,6 +2242,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Rosario + Vampire",
       "game_region": "JPN",
       "base_name": "New Super Mario Bros. ",
@@ -1993,6 +2251,7 @@
       "notes": "English patch also works too."
     },
     {
+      "rendersize": null,
       "game_name": "Rune Factory",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -2001,6 +2260,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Rune Factory 2",
       "game_region": "USA",
       "base_name": "Mario Kart DS",
@@ -2009,6 +2269,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Rune Factory 3",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -2017,6 +2278,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "SaGa 2: Hihou Densetsu - Goddess of Destiny",
       "game_region": "JPN",
       "base_name": "Kirby's Squeak Squad",
@@ -2025,6 +2287,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "SaGa 3 - Shadow or Light",
       "game_region": "JPN",
       "base_name": "New Super Mario Bros.",
@@ -2033,6 +2296,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Scribblenauts",
       "game_region": "USA",
       "base_name": "The Legend of Zelda Spirit Tracks",
@@ -2041,6 +2305,7 @@
       "notes": "Works great. No issues so far."
     },
     {
+      "rendersize": null,
       "game_name": "SEGA Superstars Tennis",
       "game_region": "USA",
       "base_name": "Kirby Mass Attack",
@@ -2049,6 +2314,7 @@
       "notes": "Minor GFX glitches."
     },
     {
+      "rendersize": null,
       "game_name": "Shenyou Maliou DS",
       "game_region": "China",
       "base_name": "Super Mario 64 DS",
@@ -2057,6 +2323,7 @@
       "notes": "Chinese version of Super Mario 64 DS. Changing hex value at 1D from 80 to 00 does bypass the ONLY FOR iQue DS screen. The touchscreen doesn't work, so you can't touch the star."
     },
     {
+      "rendersize": null,
       "game_name": "Shin Megami Tensei: Devil Survivor",
       "game_region": "USA",
       "base_name": "Brain Age: Train Your Brain in Minutes a Day!",
@@ -2065,6 +2332,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Shin Megami Tensei: Devil Survivor 2",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -2073,6 +2341,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Shin Megami Tensei: Strange Journey",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -2081,6 +2350,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Shiren the Wanderer",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -2089,6 +2359,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Solatorbo",
       "game_region": "EUR",
       "base_name": "Fire Emblem - Shadow Dragon",
@@ -2097,6 +2368,7 @@
       "notes": "Black screen"
     },
     {
+      "rendersize": null,
       "game_name": "Sonic & All Stars Racing",
       "game_region": "EUR",
       "base_name": "Mario Kart DS",
@@ -2105,6 +2377,7 @@
       "notes": "The Bottom screen flashes for a second while going into a Race, Time trial and Mission. Working great."
     },
     {
+      "rendersize": null,
       "game_name": "Sonic Chronicles: The Dark Brotherhood",
       "game_region": "USA",
       "base_name": "Yoshi Touch & Go",
@@ -2113,6 +2386,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Sonic Colors",
       "game_region": "EUR",
       "base_name": "WarioWare: Touched!",
@@ -2121,6 +2395,7 @@
       "notes": "Works perfectly fine with no gameplay or graphical issues until a boss battle, Namely the first boss at Tropical Resort, At the Start of it, The bottom screen glitches to black, even tried to change the layout of the screens and still freezes the bottom screen."
     },
     {
+      "rendersize": null,
       "game_name": "Sonic Colours",
       "game_region": "USA",
       "base_name": "Metroid Prime Hunters",
@@ -2129,22 +2404,7 @@
       "notes": "None"
     },
     {
-      "game_name": "Sonic Rush",
-      "game_region": "USA",
-      "base_name": "Metroid Prime Hunters",
-      "base_region": "USA",
-      "status": 2,
-      "notes": "None"
-    },
-    {
-      "game_name": "Sonic Rush",
-      "game_region": "USA",
-      "base_name": "Legend of Zelda: Spirit Tracks",
-      "base_region": "USA",
-      "status": 2,
-      "notes": "None"
-    },
-    {
+      "rendersize": null,
       "game_name": "Sonic Rush",
       "game_region": "EUR",
       "base_name": "Legend of Zelda: Spirit Tracks",
@@ -2153,6 +2413,25 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
+      "game_name": "Sonic Rush",
+      "game_region": "USA",
+      "base_name": "Metroid Prime Hunters",
+      "base_region": "USA",
+      "status": 2,
+      "notes": "None"
+    },
+    {
+      "rendersize": null,
+      "game_name": "Sonic Rush",
+      "game_region": "USA",
+      "base_name": "Legend of Zelda: Spirit Tracks",
+      "base_region": "USA",
+      "status": 2,
+      "notes": "None"
+    },
+    {
+      "rendersize": null,
       "game_name": "Sonic Rush Adventure",
       "game_region": "USA",
       "base_name": "Metroid Prime Hunters",
@@ -2161,6 +2440,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Space Invaders Extreme 2",
       "game_region": "USA",
       "base_name": "Kirby Mass Attack",
@@ -2169,6 +2449,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Spider-Man: Web of Shadows",
       "game_region": "USA",
       "base_name": "Mario Kart DS",
@@ -2177,6 +2458,7 @@
       "notes": "Play this game if you love Metroidvania games, you owe it to yourself"
     },
     {
+      "rendersize": null,
       "game_name": "Star Wars Episode III: Revenge of the Sith",
       "game_region": "USA",
       "base_name": "Mario Kart DS",
@@ -2185,6 +2467,7 @@
       "notes": "Maybe some graphical errors from time to time but they also occur on the physical cartridge so not a massive problem"
     },
     {
+      "rendersize": null,
       "game_name": "Suikoden - Tierkreis",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -2193,6 +2476,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Suikoden Tierkreis",
       "game_region": "USA",
       "base_name": "The Legend of Zelda: Spirit Tracks",
@@ -2201,6 +2485,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Summon Night - Twin Age",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -2209,6 +2494,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Super Mario 256",
       "game_region": "EUR",
       "base_name": "New Super Mario Bros",
@@ -2217,6 +2503,7 @@
       "notes": "Unsure if Loadiine or Wup Installable. The frames sometimes drop."
     },
     {
+      "rendersize": null,
       "game_name": "Super Monkey Ball: Touch & Roll",
       "game_region": "USA",
       "base_name": "Metroid Prime Hunters",
@@ -2225,6 +2512,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Super Princess Peach",
       "game_region": "EUR",
       "base_name": "Metroid Prime Hunters",
@@ -2233,6 +2521,7 @@
       "notes": "Freezes at white screen after loading the game."
     },
     {
+      "rendersize": null,
       "game_name": "Super Robot Taisen Mugen no Frontier Exceed (English Patch)",
       "game_region": "JPN",
       "base_name": "New Super Mario Bros",
@@ -2241,6 +2530,7 @@
       "notes": "English Patch from https://www.romhacking.net/translations/5492/"
     },
     {
+      "rendersize": null,
       "game_name": "Taiko no Tatsujin DS - Dororon Yokai Daikessen",
       "game_region": "JPN",
       "base_name": "Yoshi Touch & Go",
@@ -2249,6 +2539,7 @@
       "notes": "Other base roms I tried had different issues, from flickering, black lower screen and soft lock on exit. But this combination has worked fine so far."
     },
     {
+      "rendersize": null,
       "game_name": "Taiko no Tatsujin DS - Touch de Dokodon",
       "game_region": "JPN",
       "base_name": "Yoshi Touch & Go",
@@ -2257,6 +2548,7 @@
       "notes": "Other base roms I tried had different issues, from flickering, black lower screen and soft lock on exit. But this combination has worked fine so far."
     },
     {
+      "rendersize": null,
       "game_name": "Tales of Innocence",
       "game_region": "JPN",
       "base_name": "Yoshi Touch & Go",
@@ -2265,6 +2557,7 @@
       "notes": "Graphical glitches."
     },
     {
+      "rendersize": null,
       "game_name": "Tales of the Tempest",
       "game_region": "JPN",
       "base_name": "Yoshi Touch & Go",
@@ -2273,6 +2566,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Tengen Toppa Gurren Lagann",
       "game_region": "JPN",
       "base_name": "New Super Mario Bros",
@@ -2281,6 +2575,7 @@
       "notes": "English Patch also works too"
     },
     {
+      "rendersize": null,
       "game_name": "Tetris DS",
       "game_region": "USA",
       "base_name": "Mario Kart DS",
@@ -2289,6 +2584,7 @@
       "notes": "Loadiine tested only"
     },
     {
+      "rendersize": null,
       "game_name": "Tetris DS",
       "game_region": "USA",
       "base_name": "Metroid Prime Hunters",
@@ -2297,6 +2593,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "The Dark Spire",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -2305,6 +2602,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "The Legend of Zelda: Phantom Hourglass",
       "game_region": "USA",
       "base_name": "The Legend of Zelda: Spirit Tracks US",
@@ -2313,6 +2611,7 @@
       "notes": "Compatible with the D-pad patch: https://www.romhacking.net/hacks/2248/"
     },
     {
+      "rendersize": null,
       "game_name": "The Legend of Zelda: Spirit Tracks",
       "game_region": "USA",
       "base_name": "The Legend of Zelda: Spirit Tracks US",
@@ -2321,6 +2620,7 @@
       "notes": "Compatible with the D-pad patch: https://www.romhacking.net/hacks/2248/"
     },
     {
+      "rendersize": null,
       "game_name": "The Legendary Starfy",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -2329,6 +2629,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "The Whole Dementium Duology",
       "game_region": "USA",
       "base_name": "Metroid Prime Hunter",
@@ -2337,6 +2638,7 @@
       "notes": "The game runs pretty well haven’t experienced any problems and it feels nice with the gamepad as bottom screen and game as top screen."
     },
     {
+      "rendersize": null,
       "game_name": "The Wizard of Oz: Beyond the Yellow Brick Road",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -2345,14 +2647,7 @@
       "notes": "System crashes at the D3Publisher intro logo screen."
     },
     {
-      "game_name": "The World Ends With You",
-      "game_region": "USA",
-      "base_name": "The Legend of Zelda Phantom Hourglass",
-      "base_region": "USA",
-      "status": 0,
-      "notes": "Freezes after first battle."
-    },
-    {
+      "rendersize": null,
       "game_name": "The World Ends With You",
       "game_region": "EUR",
       "base_name": "The Legend of Zelda Phantom Hourglass",
@@ -2361,6 +2656,16 @@
       "notes": "Same issue as listed on the compatibility list for the US version (crashes after the first battle). You need to import a save after the first Battle to bypass the crash. This makes Day 1 unplayable on Wii U"
     },
     {
+      "rendersize": null,
+      "game_name": "The World Ends With You",
+      "game_region": "USA",
+      "base_name": "The Legend of Zelda Phantom Hourglass",
+      "base_region": "USA",
+      "status": 0,
+      "notes": "Freezes after first battle."
+    },
+    {
+      "rendersize": null,
       "game_name": "Theresia, Dear Emile",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -2369,6 +2674,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Time Hollow",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -2377,6 +2683,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Tom and Jerry Tales",
       "game_region": "EUR",
       "base_name": "Mario Kart DS",
@@ -2385,6 +2692,7 @@
       "notes": "Minor graphical glitches"
     },
     {
+      "rendersize": null,
       "game_name": "Tomodachi Collection",
       "game_region": "JPN",
       "base_name": "Kirby's Canvas Curse",
@@ -2393,6 +2701,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Trackmania DS",
       "game_region": "EUR",
       "base_name": "Picross 3D",
@@ -2401,6 +2710,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Transformers Revenge of the Fallen: Autobots",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -2409,6 +2719,7 @@
       "notes": "BGM Audio is broken."
     },
     {
+      "rendersize": null,
       "game_name": "Transformers Revenge of the Fallen: Decepticons",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -2417,6 +2728,7 @@
       "notes": "BGM Audio is broken."
     },
     {
+      "rendersize": null,
       "game_name": "Transformers: Deceptions",
       "game_region": "USA",
       "base_name": "Pictocross 3D",
@@ -2425,6 +2737,7 @@
       "notes": "Some glitches will happen when I tried using New Super Mario Bros as base, but not really anymore with Picross as base, game works just fine. I keep you updated"
     },
     {
+      "rendersize": null,
       "game_name": "Transformers: The Game Autobots",
       "game_region": "USA",
       "base_name": "Pictocross 3D",
@@ -2433,6 +2746,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Trauma Center: Under the Knife",
       "game_region": "USA",
       "base_name": "Yoshi Touch & Go",
@@ -2441,6 +2755,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Trauma Center: Under the Knife 2",
       "game_region": "USA",
       "base_name": "Yoshi Touch & Go",
@@ -2449,6 +2764,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Ultimate Spider-Man",
       "game_region": "EUR",
       "base_name": "Picross 3D",
@@ -2457,6 +2773,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "WarioWare D.I.Y.",
       "game_region": "USA",
       "base_name": "Kirby Squeak Squad",
@@ -2465,6 +2782,7 @@
       "notes": "Can't save in-game, so you have to use a VC Restore Point."
     },
     {
+      "rendersize": null,
       "game_name": "What's Cooking? with Jamie Oliver",
       "game_region": "EUR",
       "base_name": "Picross 3D",
@@ -2473,6 +2791,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Winx Club - Quest for the Codex",
       "game_region": "USA",
       "base_name": "Metroid Prime Hunters",
@@ -2481,6 +2800,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Xenosaga I & II",
       "game_region": "JPN",
       "base_name": "New Super Mario Bros.",
@@ -2489,6 +2809,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Ys Strategy",
       "game_region": "USA",
       "base_name": "New Super Mario Bros.",
@@ -2497,6 +2818,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Yu-Gi-Oh 5D's World Championship 2010",
       "game_region": "USA",
       "base_name": "The Legend of zelda: Spirit Tracks",
@@ -2505,6 +2827,7 @@
       "notes": "Softlocks on black screen."
     },
     {
+      "rendersize": null,
       "game_name": "Yu-Gi-Oh! World Championship 2008",
       "game_region": "USA",
       "base_name": "Kirby Mass Attack",
@@ -2513,6 +2836,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Zhigan Yi Bi",
       "game_region": "China",
       "base_name": "Metroid Prime Hunters",
@@ -2521,6 +2845,7 @@
       "notes": "Chinese version of Polarium. Just change hex value at 1D from 80 to 00 to bypass the ONLY FOR iQue DS screen."
     },
     {
+      "rendersize": null,
       "game_name": "Zhu Zhu pets 2",
       "game_region": "USA",
       "base_name": "New Super Mario Bros",
@@ -2529,6 +2854,7 @@
       "notes": "White screen"
     },
     {
+      "rendersize": null,
       "game_name": "Zombie Shiki - Eigo Ryoku Sosei Jutsu - English of the Dead",
       "game_region": "JPN",
       "base_name": "Picross 3D",
@@ -2537,6 +2863,7 @@
       "notes": "None"
     },
     {
+      "rendersize": null,
       "game_name": "Zuma's Revenge",
       "game_region": "USA",
       "base_name": "Picross 3D",


### PR DESCRIPTION
### 📌 Compatibility Entry Submission

**Submitted via:** UWUVCI V3 App  
**Bot:** UWUVCI-ContriBot  

---

### 🕹️ Game Info
- **Game Name:** MegaMan Battle Network Operate Star Force
- **Game Region:** JPN
- **Base Title:** Mario Kart DS
- **Base Region:** USA
- **Console:** NDS

---

### ✅ Compatibility
- **Status:** 2  
  - 0 = Doesn't Work  
  - 1 = Issues  
  - 2 = Works  

- **Render Size:** 1x

---

### 📝 Notes
This is patched with the fan translation (https://forums.therockmanexezone.com/rockman-exe-operate-shooting-star-translation-proj-t4427.html) of the game Rockman EXE Operate Shooting Star. (UWUVCI Version: 3.200.1)

---

### 🔗 Metadata
- Generated at: 2025-10-07 04:14 UTC  
- App Version: 3.200.1
