### PR TITLE
[Compat] Add Shaun the Sheep: Off His Head (NDS)

### DIFF
--- a/NDSCompat.json
+++ b/NDSCompat.json
@@ -2323,6 +2323,15 @@
       "notes": "Minor GFX glitches."
     },
     {
+      "rendersize": "",
+      "game_name": "Shaun the Sheep: Off His Head",
+      "game_region": "EUR",
+      "base_name": "Yoshi’s Island DS",
+      "base_region": "EUR",
+      "status": 2,
+      "notes": "(ZestyTS' UWUVCI Version: 3.201.2)"
+    },
+    {
       "rendersize": null,
       "game_name": "Shenyou Maliou DS",
       "game_region": "China",


### PR DESCRIPTION
### 📌 Compatibility Entry Submission

**Submitted via:** UWUVCI V3 App  
**Bot:** UWUVCI-ContriBot  

---

### 🕹️ Game Info
- **Game Name:** Shaun the Sheep: Off His Head
- **Game Region:** EUR
- **Base Title:** Yoshi’s Island DS
- **Base Region:** EUR
- **Console:** NDS

---

### ✅ Compatibility
- **Status:** 2  
  - 0 = Doesn't Work  
  - 1 = Issues  
  - 2 = Works  

- **Render Size:** 

---

### 📝 Notes
(ZestyTS' UWUVCI Version: 3.201.2)

---

### 🔗 Metadata
- Generated at: 2026-04-28 00:57 UTC  
- App Version: 3.201.2
- **Submitter fingerprint (FP):** `DJDiwmaPrkayVAa6mXaJIdrhSH5l6UtJEFjzGYXnF3g=`

