### PR TITLE
[Compat] Add Jordan Vs. Bird One-on-One (NES)

### DIFF
--- a/NESCompat.json
+++ b/NESCompat.json
@@ -241,6 +241,14 @@
       "notes": "Tested with Loadiine v4. Black screen on boot. Can exit ot the Wii U Menu safely."
     },
     {
+      "game_name": "Jordan Vs. Bird One-on-One",
+      "game_region": "USA",
+      "base_name": "EarthBound Beginnings",
+      "base_region": "USA",
+      "status": 1,
+      "notes": "Glitches early in gameplay; eventually screen goes black. Wii U does not freeze (ZestyTS' UWUVCI Version: 3.201.2)"
+    },
+    {
       "game_name": "King's Knight",
       "game_region": "USA",
       "base_name": "Punch Out!!",


### PR DESCRIPTION
### 📌 Compatibility Entry Submission

**Submitted via:** UWUVCI V3 App  
**Bot:** UWUVCI-ContriBot  

---

### 🕹️ Game Info
- **Game Name:** Jordan Vs. Bird One-on-One
- **Game Region:** USA
- **Base Title:** EarthBound Beginnings
- **Base Region:** USA
- **Console:** NES

---

### ✅ Compatibility
- **Status:** 1  
  - 0 = Doesn't Work  
  - 1 = Issues  
  - 2 = Works  


---

### 📝 Notes
Glitches early in gameplay; eventually screen goes black. Wii U does not freeze (ZestyTS' UWUVCI Version: 3.201.2)

---

### 🔗 Metadata
- Generated at: 2026-07-09 03:16 UTC  
- App Version: 3.201.2
- **Submitter fingerprint (FP):** `O9zqbQAL5m5DELM3MlKU/25/Q7980OSX0H2MKlEvT7o=`

