### PR TITLE
[Compat] Add Zelda II: The Adventures of Link (NES)

### DIFF
--- a/NESCompat.json
+++ b/NESCompat.json
@@ -455,6 +455,14 @@
       "base_region": "USA",
       "status": 2,
       "notes": "None"
+    },
+    {
+      "game_name": "Zelda II: The Adventures of Link",
+      "game_region": "USA",
+      "base_name": "Punch-Out!! Featuring Mr. Dream",
+      "base_region": "USA",
+      "status": 1,
+      "notes": "Glitches early in gameplay; eventually screen goes black. Wii U does not freeze (ZestyTS' UWUVCI Version: 3.201.2)"
     }
   ]
 }


### PR DESCRIPTION
### 📌 Compatibility Entry Submission

**Submitted via:** UWUVCI V3 App  
**Bot:** UWUVCI-ContriBot  

---

### 🕹️ Game Info
- **Game Name:** Zelda II: The Adventures of Link
- **Game Region:** USA
- **Base Title:** Punch-Out!! Featuring Mr. Dream
- **Base Region:** USA
- **Console:** NES

---

### ✅ Compatibility
- **Status:** 1  
  - 0 = Doesn't Work  
  - 1 = Issues  
  - 2 = Works  


---

### 📝 Notes
Glitches early in gameplay; eventually screen goes black. Wii U does not freeze (ZestyTS' UWUVCI Version: 3.201.2)

---

### 🔗 Metadata
- Generated at: 2026-07-09 03:21 UTC  
- App Version: 3.201.2
- **Submitter fingerprint (FP):** `O9zqbQAL5m5DELM3MlKU/25/Q7980OSX0H2MKlEvT7o=`

