### PR TITLE
[Compat] Add Super Mario Bros. 3 (NES)

### DIFF
--- a/NESCompat.json
+++ b/NESCompat.json
@@ -409,6 +409,14 @@
       "notes": "None"
     },
     {
+      "game_name": "Super Mario Bros. 3",
+      "game_region": "USA",
+      "base_name": "EarthBound Beginnings",
+      "base_region": "USA",
+      "status": 0,
+      "notes": "Loads to blank screen. Wii U does not freeze (ZestyTS' UWUVCI Version: 3.201.2)"
+    },
+    {
       "game_name": "Teenage Mutant Ninja Turtles",
       "game_region": "USA",
       "base_name": "Punch Out!!",


### PR DESCRIPTION
### 📌 Compatibility Entry Submission

**Submitted via:** UWUVCI V3 App  
**Bot:** UWUVCI-ContriBot  

---

### 🕹️ Game Info
- **Game Name:** Super Mario Bros. 3
- **Game Region:** USA
- **Base Title:** EarthBound Beginnings
- **Base Region:** USA
- **Console:** NES

---

### ✅ Compatibility
- **Status:** 0  
  - 0 = Doesn't Work  
  - 1 = Issues  
  - 2 = Works  


---

### 📝 Notes
Loads to blank screen. Wii U does not freeze (ZestyTS' UWUVCI Version: 3.201.2)

---

### 🔗 Metadata
- Generated at: 2026-07-09 03:24 UTC  
- App Version: 3.201.2
- **Submitter fingerprint (FP):** `O9zqbQAL5m5DELM3MlKU/25/Q7980OSX0H2MKlEvT7o=`

