### PR TITLE
[Compat] Add angry birds trilogy (Wii)

### DIFF
--- a/WIICompat.json
+++ b/WIICompat.json
@@ -109,6 +109,15 @@
       "notes": "Works on EUR region console using patch video mode."
     },
     {
+      "gamepad": 0,
+      "game_name": "angry birds trilogy",
+      "game_region": "USA",
+      "base_name": "Rhythm Heaven Fever",
+      "base_region": "(USA)",
+      "status": 0,
+      "notes": "Game does not appear to load. Console displays a black error screen and prompts the user to reset the system. (ZestyTS' UWUVCI Version: 3.201.2)"
+    },
+    {
       "gamepad": 1,
       "game_name": "Animal Crossing - City Folk",
       "game_region": "USA",


### PR DESCRIPTION
### 📌 Compatibility Entry Submission

**Submitted via:** UWUVCI V3 App  
**Bot:** UWUVCI-ContriBot  

---

### 🕹️ Game Info
- **Game Name:** angry birds trilogy
- **Game Region:** USA
- **Base Title:** Rhythm Heaven Fever
- **Base Region:** (USA)
- **Console:** Wii

---

### ✅ Compatibility
- **Status:** 0  
  - 0 = Doesn't Work  
  - 1 = Issues  
  - 2 = Works  

- **GamePad:** 0
  - 0 = No Support
  - 1 = Partial
  - 2 = Full

---

### 📝 Notes
Game does not appear to load. Console displays a black error screen and prompts the user to reset the system. (ZestyTS' UWUVCI Version: 3.201.2)

---

### 🔗 Metadata
- Generated at: 2026-07-21 13:41 UTC  
- App Version: 3.201.2
- **Submitter fingerprint (FP):** `o1b0BFhbxFHW2DCTZ+D6JGmKSziBwCAP5fL/D8k+0QA=`

